### PR TITLE
Create folder 'out' if not exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,4 +268,12 @@ out += '</script>\n\n';
 out += generate(JSXCode, {}).code;
 
 // console.log(out);
-fs.writeFileSync(`./out/out${Date.now()}.svelte`, out, { encoding: 'utf8' });
+const path = `./out/out${Date.now()}.svelte`;
+
+if (!fs.existsSync(`./out`))
+    fs.mkdirSync(`./out`);
+
+const fsp = fs.promises;
+fsp.readFile(path).catch(() => {
+    fsp.writeFile(path, out, { encoding: 'utf8'});
+});

--- a/refactor.js
+++ b/refactor.js
@@ -630,4 +630,12 @@ out = out.replace(/"}<\/HTMLxBlock>/g, '');
 
 console.log(out);
 
-fs.writeFileSync(`./out/out${Date.now()}.svelte`, out, { encoding: 'utf8' });
+const path = `./out/out${Date.now()}.svelte`;
+
+if (!fs.existsSync(`./out`))
+    fs.mkdirSync(`./out`);
+
+const fsp = fs.promises;
+fsp.readFile(path).catch(() => {
+    fsp.writeFile(path, out, { encoding: 'utf8'});
+});


### PR DESCRIPTION
Hi, was interested by your project and was testing/playing around it, then I noticed some issue with the output saving which breaks if `./out` doesn't exist, which might happen for any new contributor.

TL;DR : This is the change I made :
```diff
- fs.writeFileSync(`./out/out${Date.now()}.svelte`, out, { encoding: 'utf8' });
+ const path = `./out/out${Date.now()}.svelte`;
+ if (!fs.existsSync(`./out`))
+     fs.mkdirSync(`./out`);
+ const fsp = fs.promises;
+ fsp.readFile(path).catch(() => {
+     fsp.writeFile(path, out, { encoding: 'utf8'});
+ });
```